### PR TITLE
Add Puppet version requirements to module metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.bundle/
+Gemfile.lock
+pkg/
+spec/fixtures/

--- a/metadata.json
+++ b/metadata.json
@@ -22,5 +22,11 @@
         { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.2.0 < 5.0.0" },
         { "name": "herculesteam-augeasproviders_pam", "version_requirement": ">= 2.1.0 < 5.0.0" }
       ],
+      "requirements": [
+        {
+          "name": "puppet",
+          "version_requirement": ">= 4.0.0 < 5.0.0"
+        }
+      ],
       "data_provider": "hiera"
     }


### PR DESCRIPTION
Adds Puppet version requirements (Puppet 4.0.0 or greater, but less than 5.x) to the module's `metadata.json` file. This should help signal to users potential compatibility issues when using with unsupported Puppet versions such as #1 and #2.

Also adds a `.gitignore` file with some minimal exclusions.